### PR TITLE
MARP-1333 Missing setup path for README_DE.md in Market template

### DIFF
--- a/a-trust-connector-product/zip.xml
+++ b/a-trust-connector-product/zip.xml
@@ -20,6 +20,7 @@
       <outputDirectory>/</outputDirectory>
       <includes>
         <include>README.md</include>
+        <include>README_DE.md</include>
       </includes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
Added README_DE.md.